### PR TITLE
Fixed a problem #1

### DIFF
--- a/ESNotification.xcodeproj/project.pbxproj
+++ b/ESNotification.xcodeproj/project.pbxproj
@@ -9,6 +9,18 @@
 /* Begin PBXBuildFile section */
 		343A9A080F9C7329E71BCB52 /* Pods_ESNotification_iOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94CC4F394FDA4C6F982B9551 /* Pods_ESNotification_iOSTests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		AB3373D115BB629CB46125EE /* Pods_ESNotification_OSXTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 905E50B34A8714B9C3580F67 /* Pods_ESNotification_OSXTests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		B12BA0671B7BE0DD001F8080 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12BA0661B7BE0DD001F8080 /* AppDelegate.swift */; };
+		B12BA0691B7BE0DD001F8080 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12BA0681B7BE0DD001F8080 /* ViewController.swift */; };
+		B12BA06B1B7BE0DD001F8080 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B12BA06A1B7BE0DD001F8080 /* Assets.xcassets */; };
+		B12BA06E1B7BE0DD001F8080 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B12BA06C1B7BE0DD001F8080 /* Main.storyboard */; };
+		B12BA0761B7BE1BE001F8080 /* ModalWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12BA0751B7BE1BE001F8080 /* ModalWindowController.swift */; };
+		B12BA0791B7BE313001F8080 /* ESNotification.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B17475BC1B6CD4EB00A86785 /* ESNotification.framework */; };
+		B12BA07B1B7BE335001F8080 /* ESNotification.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B17475BC1B6CD4EB00A86785 /* ESNotification.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B12BA0801B7BE504001F8080 /* ModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12BA07F1B7BE504001F8080 /* ModalViewController.swift */; };
+		B12BA0821B7BE587001F8080 /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12BA0811B7BE587001F8080 /* Notification.swift */; };
+		B12BA0841B7BEB2F001F8080 /* ModalWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12BA0831B7BEB2F001F8080 /* ModalWindow.swift */; };
+		B12BA0861B7C0723001F8080 /* NotificationControl_OSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12BA0851B7C0723001F8080 /* NotificationControl_OSX.swift */; };
+		B12BA0881B7C072E001F8080 /* NotificationControl_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12BA0871B7C072E001F8080 /* NotificationControl_iOS.swift */; };
 		B17475A31B6CD4DE00A86785 /* ESNotification_iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = B17475A21B6CD4DE00A86785 /* ESNotification_iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B17475AA1B6CD4DE00A86785 /* ESNotification.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B17475A01B6CD4DE00A86785 /* ESNotification.framework */; };
 		B17475BF1B6CD4EB00A86785 /* ESNotification_OSX.h in Headers */ = {isa = PBXBuildFile; fileRef = B17475BE1B6CD4EB00A86785 /* ESNotification_OSX.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -27,11 +39,19 @@
 		B17475F31B6CE0D500A86785 /* RawNotificationConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17475E51B6CE0D500A86785 /* RawNotificationConvertible.swift */; };
 		B17475F61B6CE11200A86785 /* NotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17475F51B6CE11200A86785 /* NotificationTests.swift */; };
 		B17475F71B6CE11200A86785 /* NotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17475F51B6CE11200A86785 /* NotificationTests.swift */; };
+		C8F822083B65523B72E837B0 /* Pods_RunModalTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE62C38B0D23D1E3CFE0B2F2 /* Pods_RunModalTestApp.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		DA4177733F8741AACC0E09FD /* Pods_ESNotification_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD38000B9128AF3843B606EA /* Pods_ESNotification_iOS.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		E6CD40E556A62094744B1512 /* Pods_ESNotification_OSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C90ECBF946957FD1DEBF1072 /* Pods_ESNotification_OSX.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		B12BA07C1B7BE335001F8080 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B174755C1B6CD4A500A86785 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B17475BB1B6CD4EB00A86785;
+			remoteInfo = ESNotification_OSX;
+		};
 		B17475AB1B6CD4DE00A86785 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B174755C1B6CD4A500A86785 /* Project object */;
@@ -48,8 +68,23 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		B12BA07E1B7BE336001F8080 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				B12BA07B1B7BE335001F8080 /* ESNotification.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		08599E89B6F81AB8EE375CB7 /* Pods-ESNotification_iOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ESNotification_iOSTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ESNotification_iOSTests/Pods-ESNotification_iOSTests.debug.xcconfig"; sourceTree = "<group>"; };
+		0E75ADA5C13DF748C994DCA4 /* Pods-RunModalTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunModalTestApp.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RunModalTestApp/Pods-RunModalTestApp.debug.xcconfig"; sourceTree = "<group>"; };
 		1D438E63263B9A68693E15AA /* Pods-ESNotification_OSXTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ESNotification_OSXTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ESNotification_OSXTests/Pods-ESNotification_OSXTests.debug.xcconfig"; sourceTree = "<group>"; };
 		3019E78420CB833E27358A53 /* Pods-ESNotification_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ESNotification_iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-ESNotification_iOS/Pods-ESNotification_iOS.release.xcconfig"; sourceTree = "<group>"; };
 		30FAB848E9645FDCA427653B /* Pods-ESNotification_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ESNotification_iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ESNotification_iOS/Pods-ESNotification_iOS.debug.xcconfig"; sourceTree = "<group>"; };
@@ -58,6 +93,19 @@
 		7132ACFF95924D2451FF3898 /* Pods-ESNotification_OSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ESNotification_OSX.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ESNotification_OSX/Pods-ESNotification_OSX.debug.xcconfig"; sourceTree = "<group>"; };
 		905E50B34A8714B9C3580F67 /* Pods_ESNotification_OSXTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ESNotification_OSXTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		94CC4F394FDA4C6F982B9551 /* Pods_ESNotification_iOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ESNotification_iOSTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9ED0AC1A97F60B8A36918B54 /* Pods-RunModalTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunModalTestApp.release.xcconfig"; path = "Pods/Target Support Files/Pods-RunModalTestApp/Pods-RunModalTestApp.release.xcconfig"; sourceTree = "<group>"; };
+		B12BA0641B7BE0DD001F8080 /* RunModalTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RunModalTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		B12BA0661B7BE0DD001F8080 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		B12BA0681B7BE0DD001F8080 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		B12BA06A1B7BE0DD001F8080 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B12BA06D1B7BE0DD001F8080 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		B12BA06F1B7BE0DD001F8080 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B12BA0751B7BE1BE001F8080 /* ModalWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModalWindowController.swift; sourceTree = "<group>"; };
+		B12BA07F1B7BE504001F8080 /* ModalViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModalViewController.swift; sourceTree = "<group>"; };
+		B12BA0811B7BE587001F8080 /* Notification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
+		B12BA0831B7BEB2F001F8080 /* ModalWindow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModalWindow.swift; sourceTree = "<group>"; };
+		B12BA0851B7C0723001F8080 /* NotificationControl_OSX.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationControl_OSX.swift; sourceTree = "<group>"; };
+		B12BA0871B7C072E001F8080 /* NotificationControl_iOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationControl_iOS.swift; sourceTree = "<group>"; };
 		B17475A01B6CD4DE00A86785 /* ESNotification.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ESNotification.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B17475A21B6CD4DE00A86785 /* ESNotification_iOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ESNotification_iOS.h; sourceTree = "<group>"; };
 		B17475A41B6CD4DE00A86785 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -81,10 +129,20 @@
 		B1E89A7A1B745F5F0062E12E /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		BD38000B9128AF3843B606EA /* Pods_ESNotification_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ESNotification_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C90ECBF946957FD1DEBF1072 /* Pods_ESNotification_OSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ESNotification_OSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DE62C38B0D23D1E3CFE0B2F2 /* Pods_RunModalTestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunModalTestApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F3F5EEE9FEE59F10E3873CAC /* Pods-ESNotification_OSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ESNotification_OSX.release.xcconfig"; path = "Pods/Target Support Files/Pods-ESNotification_OSX/Pods-ESNotification_OSX.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		B12BA0611B7BE0DD001F8080 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B12BA0791B7BE313001F8080 /* ESNotification.framework in Frameworks */,
+				C8F822083B65523B72E837B0 /* Pods_RunModalTestApp.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B174759C1B6CD4DE00A86785 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -129,6 +187,7 @@
 				905E50B34A8714B9C3580F67 /* Pods_ESNotification_OSXTests.framework */,
 				BD38000B9128AF3843B606EA /* Pods_ESNotification_iOS.framework */,
 				94CC4F394FDA4C6F982B9551 /* Pods_ESNotification_iOSTests.framework */,
+				DE62C38B0D23D1E3CFE0B2F2 /* Pods_RunModalTestApp.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -144,8 +203,26 @@
 				3019E78420CB833E27358A53 /* Pods-ESNotification_iOS.release.xcconfig */,
 				08599E89B6F81AB8EE375CB7 /* Pods-ESNotification_iOSTests.debug.xcconfig */,
 				5533CF9D94848F3539FF9D05 /* Pods-ESNotification_iOSTests.release.xcconfig */,
+				0E75ADA5C13DF748C994DCA4 /* Pods-RunModalTestApp.debug.xcconfig */,
+				9ED0AC1A97F60B8A36918B54 /* Pods-RunModalTestApp.release.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		B12BA0651B7BE0DD001F8080 /* RunModalTestApp */ = {
+			isa = PBXGroup;
+			children = (
+				B12BA0661B7BE0DD001F8080 /* AppDelegate.swift */,
+				B12BA0681B7BE0DD001F8080 /* ViewController.swift */,
+				B12BA0751B7BE1BE001F8080 /* ModalWindowController.swift */,
+				B12BA07F1B7BE504001F8080 /* ModalViewController.swift */,
+				B12BA0831B7BEB2F001F8080 /* ModalWindow.swift */,
+				B12BA0811B7BE587001F8080 /* Notification.swift */,
+				B12BA06A1B7BE0DD001F8080 /* Assets.xcassets */,
+				B12BA06C1B7BE0DD001F8080 /* Main.storyboard */,
+				B12BA06F1B7BE0DD001F8080 /* Info.plist */,
+			);
+			path = RunModalTestApp;
 			sourceTree = "<group>";
 		};
 		B174755B1B6CD4A500A86785 = {
@@ -161,6 +238,7 @@
 				B17475AD1B6CD4DE00A86785 /* ESNotification_iOSTests */,
 				B17475BD1B6CD4EB00A86785 /* ESNotification_OSX */,
 				B17475C91B6CD4EB00A86785 /* ESNotification_OSXTests */,
+				B12BA0651B7BE0DD001F8080 /* RunModalTestApp */,
 				B17475661B6CD4A500A86785 /* Products */,
 				2D12B598E411EF0DA6582D29 /* Pods */,
 				231D6053F4AABA988815BC2A /* Frameworks */,
@@ -174,6 +252,7 @@
 				B17475A91B6CD4DE00A86785 /* ESNotification_iOSTests.xctest */,
 				B17475BC1B6CD4EB00A86785 /* ESNotification.framework */,
 				B17475C51B6CD4EB00A86785 /* ESNotification_OSXTests.xctest */,
+				B12BA0641B7BE0DD001F8080 /* RunModalTestApp.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -204,6 +283,7 @@
 			children = (
 				B17475A21B6CD4DE00A86785 /* ESNotification_iOS.h */,
 				B17475A41B6CD4DE00A86785 /* Info.plist */,
+				B12BA0871B7C072E001F8080 /* NotificationControl_iOS.swift */,
 			);
 			path = ESNotification_iOS;
 			sourceTree = "<group>";
@@ -221,6 +301,7 @@
 			children = (
 				B17475BE1B6CD4EB00A86785 /* ESNotification_OSX.h */,
 				B17475C01B6CD4EB00A86785 /* Info.plist */,
+				B12BA0851B7C0723001F8080 /* NotificationControl_OSX.swift */,
 			);
 			path = ESNotification_OSX;
 			sourceTree = "<group>";
@@ -255,6 +336,28 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		B12BA0631B7BE0DD001F8080 /* RunModalTestApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B12BA0721B7BE0DD001F8080 /* Build configuration list for PBXNativeTarget "RunModalTestApp" */;
+			buildPhases = (
+				CFBF2217676031C5B0800077 /* Check Pods Manifest.lock */,
+				B12BA0601B7BE0DD001F8080 /* Sources */,
+				B12BA0611B7BE0DD001F8080 /* Frameworks */,
+				B12BA0621B7BE0DD001F8080 /* Resources */,
+				B12BA07E1B7BE336001F8080 /* Embed Frameworks */,
+				67AF9D30954DE6EF9F8D5CB0 /* Embed Pods Frameworks */,
+				4859CBD23844D70A99C46961 /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B12BA07D1B7BE335001F8080 /* PBXTargetDependency */,
+			);
+			name = RunModalTestApp;
+			productName = RunModalTestApp;
+			productReference = B12BA0641B7BE0DD001F8080 /* RunModalTestApp.app */;
+			productType = "com.apple.product-type.application";
+		};
 		B174759F1B6CD4DE00A86785 /* ESNotification_iOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B17475B11B6CD4DE00A86785 /* Build configuration list for PBXNativeTarget "ESNotification_iOS" */;
@@ -347,6 +450,9 @@
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "EasyStyle G.K.";
 				TargetAttributes = {
+					B12BA0631B7BE0DD001F8080 = {
+						CreatedOnToolsVersion = 7.0;
+					};
 					B174759F1B6CD4DE00A86785 = {
 						CreatedOnToolsVersion = 7.0;
 					};
@@ -367,6 +473,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = B174755B1B6CD4A500A86785;
 			productRefGroup = B17475661B6CD4A500A86785 /* Products */;
@@ -377,11 +484,21 @@
 				B17475BB1B6CD4EB00A86785 /* ESNotification_OSX */,
 				B17475A81B6CD4DE00A86785 /* ESNotification_iOSTests */,
 				B17475C41B6CD4EB00A86785 /* ESNotification_OSXTests */,
+				B12BA0631B7BE0DD001F8080 /* RunModalTestApp */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		B12BA0621B7BE0DD001F8080 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B12BA06B1B7BE0DD001F8080 /* Assets.xcassets in Resources */,
+				B12BA06E1B7BE0DD001F8080 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B174759E1B6CD4DE00A86785 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -488,6 +605,36 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
+		4859CBD23844D70A99C46961 /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RunModalTestApp/Pods-RunModalTestApp-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		67AF9D30954DE6EF9F8D5CB0 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RunModalTestApp/Pods-RunModalTestApp-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9FC3A245E2C79476443C0D32 /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -533,6 +680,21 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ESNotification_OSXTests/Pods-ESNotification_OSXTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		CFBF2217676031C5B0800077 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
 		DA3417E3C37B6CC40F82BF84 /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -566,6 +728,19 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		B12BA0601B7BE0DD001F8080 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B12BA0801B7BE504001F8080 /* ModalViewController.swift in Sources */,
+				B12BA0821B7BE587001F8080 /* Notification.swift in Sources */,
+				B12BA0691B7BE0DD001F8080 /* ViewController.swift in Sources */,
+				B12BA0841B7BEB2F001F8080 /* ModalWindow.swift in Sources */,
+				B12BA0671B7BE0DD001F8080 /* AppDelegate.swift in Sources */,
+				B12BA0761B7BE1BE001F8080 /* ModalWindowController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B174759B1B6CD4DE00A86785 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -573,6 +748,7 @@
 				B17475E81B6CE0D500A86785 /* Notification.swift in Sources */,
 				B17475EE1B6CE0D500A86785 /* NamedNotification.swift in Sources */,
 				B17475F21B6CE0D500A86785 /* RawNotificationConvertible.swift in Sources */,
+				B12BA0881B7C072E001F8080 /* NotificationControl_iOS.swift in Sources */,
 				B17475F01B6CE0D500A86785 /* AnyNotification.swift in Sources */,
 				B17475EC1B6CE0D500A86785 /* NotificationManager.swift in Sources */,
 				B17475EA1B6CE0D500A86785 /* NotificationControl.swift in Sources */,
@@ -594,6 +770,7 @@
 				B17475E91B6CE0D500A86785 /* Notification.swift in Sources */,
 				B17475EF1B6CE0D500A86785 /* NamedNotification.swift in Sources */,
 				B17475F31B6CE0D500A86785 /* RawNotificationConvertible.swift in Sources */,
+				B12BA0861B7C0723001F8080 /* NotificationControl_OSX.swift in Sources */,
 				B17475F11B6CE0D500A86785 /* AnyNotification.swift in Sources */,
 				B17475ED1B6CE0D500A86785 /* NotificationManager.swift in Sources */,
 				B17475EB1B6CE0D500A86785 /* NotificationControl.swift in Sources */,
@@ -611,6 +788,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		B12BA07D1B7BE335001F8080 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B17475BB1B6CD4EB00A86785 /* ESNotification_OSX */;
+			targetProxy = B12BA07C1B7BE335001F8080 /* PBXContainerItemProxy */;
+		};
 		B17475AC1B6CD4DE00A86785 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = B174759F1B6CD4DE00A86785 /* ESNotification_iOS */;
@@ -623,7 +805,50 @@
 		};
 /* End PBXTargetDependency section */
 
+/* Begin PBXVariantGroup section */
+		B12BA06C1B7BE0DD001F8080 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				B12BA06D1B7BE0DD001F8080 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
 /* Begin XCBuildConfiguration section */
+		B12BA0701B7BE0DD001F8080 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0E75ADA5C13DF748C994DCA4 /* Pods-RunModalTestApp.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				INFOPLIST_FILE = RunModalTestApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = "jp.ez-style.appid.RunModalTestApp";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		B12BA0711B7BE0DD001F8080 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9ED0AC1A97F60B8A36918B54 /* Pods-RunModalTestApp.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				INFOPLIST_FILE = RunModalTestApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = "jp.ez-style.appid.RunModalTestApp";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		B17475771B6CD4A500A86785 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -790,6 +1015,7 @@
 			baseConfigurationReference = 7132ACFF95924D2451FF3898 /* Pods-ESNotification_OSX.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -812,6 +1038,7 @@
 			baseConfigurationReference = F3F5EEE9FEE59F10E3873CAC /* Pods-ESNotification_OSX.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -857,6 +1084,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		B12BA0721B7BE0DD001F8080 /* Build configuration list for PBXNativeTarget "RunModalTestApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B12BA0701B7BE0DD001F8080 /* Debug */,
+				B12BA0711B7BE0DD001F8080 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		B174755F1B6CD4A500A86785 /* Build configuration list for PBXProject "ESNotification" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/ESNotification.xcodeproj/xcuserdata/tomohiro.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/ESNotification.xcodeproj/xcuserdata/tomohiro.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,16 +7,26 @@
 		<key>ESNotification_OSX.xcscheme</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>ESNotification_iOS.xcscheme</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>2</integer>
+			<integer>1</integer>
+		</dict>
+		<key>RunModalTestApp.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>16</integer>
 		</dict>
 	</dict>
 	<key>SuppressBuildableAutocreation</key>
 	<dict>
+		<key>B12BA0631B7BE0DD001F8080</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
 		<key>B17475641B6CD4A500A86785</key>
 		<dict>
 			<key>primary</key>

--- a/ESNotification/NamedNotification.swift
+++ b/ESNotification/NamedNotification.swift
@@ -11,7 +11,7 @@ import Foundation
 /// This Notification represent almost the same thing as NSNotification.
 @objc public class NamedNotification : NSObject, Notification, RawNotificationConvertible, RawNotificationType {
 	
-	public typealias UserInfo = [NSObject:AnyObject]
+	public typealias UserInfo = [NSObject : AnyObject]
 	
 	public private(set) var name:String
 	public private(set) var object:AnyObject?
@@ -36,10 +36,35 @@ import Foundation
 		super.init()
 	}
 	
+//	public func copyWithZone(zone: NSZone) -> AnyObject {
+//		
+//		let result = NamedNotification(self.name.copy() as! String)
+//		
+//		if let object = self.object where object.respondsToSelector("copyWithZone:") {
+//			
+//			result.object = object.copy()
+//		}
+//		else {
+//
+//			result.object = self.object
+//		}
+//		
+//		if let userInfo = self.userInfo {
+//			
+//			result.userInfo = (userInfo as NSDictionary).copy() as? UserInfo
+//		}
+//		else {
+//			
+//			result.userInfo = self.userInfo
+//		}
+//		
+//		return result
+//	}
+	
 	/// Initialize with a Raw Notification.
 	public required convenience init(rawNotification:NSNotification) {
 		
-		self.init(rawNotification.name, object:rawNotification.object, userInfo:rawNotification.userInfo)
+		self.init(rawNotification.name, object:rawNotification.object as? NSObject, userInfo:rawNotification.userInfo)
 	}
 	
 	/// Get a Raw Notification.

--- a/ESNotification/NotificationControl.swift
+++ b/ESNotification/NotificationControl.swift
@@ -86,13 +86,13 @@ private let _processingQueueLabel = "jp.ez-style.thread.ocean.notification"
 private let _processingQueue = dispatch_queue_create(_processingQueueLabel, nil)
 
 /// Invoke `predicate` asynchronously on the thread for Notification processing.
-public let invokeOnProcessingQueue:(predicate:()->Void) -> Void = {
+public func invokeOnProcessingQueue(predicate:()->Void) -> Void {
 	
-	invokeAsync(_processingQueue, predicate: $0)
+	invokeAsync(_processingQueue, predicate: predicate)
 }
 
 /// Invoke `predicate` synchronously on the thread for Notification processing.
-func invokeOnProcessingQueueSynchronously<R>(predicate:()->R) -> R {
+public func invokeOnProcessingQueueSynchronously<R>(predicate:()->R) -> R {
 	
 	return invoke(_processingQueue, predicate: predicate)
 }

--- a/ESNotification/NotificationManager.swift
+++ b/ESNotification/NotificationManager.swift
@@ -171,7 +171,7 @@ extension NotificationManager {
 	/// The method is called when the observer received an notification.
 	func received(notification:Notification) {
 
-		invokeOnProcessingQueue {
+		invokeOnProcessingQueueSyncIfNeeded {
 
 			self._removeUnownedNotificationHandlers()
 			
@@ -284,7 +284,7 @@ class _NotificationObserver : NSObject {
 			self._manager.received(notification)
 		}
 		else {
-			
+
 			self._manager.received(NamedNotification(rawNotification: rawNotification))
 		}
 	}

--- a/ESNotification_OSX/NotificationControl_OSX.swift
+++ b/ESNotification_OSX/NotificationControl_OSX.swift
@@ -1,0 +1,17 @@
+//
+//  NotificationControl_OSX.swift
+//  ESNotification
+//
+//  Created by Tomohiro Kumagai on H27/08/13.
+//  Copyright © 平成27年 EasyStyle G.K. All rights reserved.
+//
+
+import Cocoa
+
+public func invokeOnProcessingQueueSyncIfNeeded(predicate:()->Void) -> Void {
+
+	// In OSX, always invoke synchronously.
+	// Because when modal window shown from menu in OSX, need to invoke synchronously.
+	// Otherwise the app clash when _NSWindowTransformAnimation notification is received.
+	invokeOnProcessingQueueSynchronously(predicate)
+}

--- a/ESNotification_iOS/NotificationControl_iOS.swift
+++ b/ESNotification_iOS/NotificationControl_iOS.swift
@@ -1,0 +1,13 @@
+//
+//  NotificationControl_iOS.swift
+//  ESNotification
+//
+//  Created by Tomohiro Kumagai on H27/08/13.
+//  Copyright © 平成27年 EasyStyle G.K. All rights reserved.
+//
+
+public func invokeOnProcessingQueueSyncIfNeeded(predicate:()->Void) -> Void {
+	
+	// In iOS, always invoke asynchronously.
+	invokeOnProcessingQueue(predicate)
+}

--- a/Podfile
+++ b/Podfile
@@ -31,6 +31,13 @@ target :ESNotification_iOS do
 
 end
 
+target :RunModalTestApp do
+	
+	platform :osx, '10.10'
+	pods
+	
+end
+
 target :ESNotification_OSXTests do
 	
 	platform :osx, '10.10'

--- a/RunModalTestApp/AppDelegate.swift
+++ b/RunModalTestApp/AppDelegate.swift
@@ -1,0 +1,30 @@
+//
+//  AppDelegate.swift
+//  RunModalTestApp
+//
+//  Created by Tomohiro Kumagai on H27/08/13.
+//  Copyright © 平成27年 EasyStyle G.K. All rights reserved.
+//
+
+import Cocoa
+
+@NSApplicationMain
+class AppDelegate: NSObject, NSApplicationDelegate {
+
+	func applicationDidFinishLaunching(aNotification: NSNotification) {
+		// Insert code here to initialize your application
+	}
+
+	func applicationWillTerminate(aNotification: NSNotification) {
+		// Insert code here to tear down your application
+	}
+
+	@IBAction func showModal(sender:AnyObject!) {
+		
+		let storyboard = NSStoryboard(name: "Main", bundle: nil)
+		let controller = storyboard.instantiateControllerWithIdentifier("ModalWindow") as! NSWindowController
+		
+		NSApp.runModalForWindow(controller.window!)
+	}
+}
+

--- a/RunModalTestApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/RunModalTestApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "512x512",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "512x512",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/RunModalTestApp/Base.lproj/Main.storyboard
+++ b/RunModalTestApp/Base.lproj/Main.storyboard
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="8173.3" systemVersion="14E46" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8173.3"/>
+    </dependencies>
+    <scenes>
+        <!--Application-->
+        <scene sceneID="JPo-4y-FX3">
+            <objects>
+                <application id="hnw-xV-0zn" sceneMemberID="viewController">
+                    <menu key="mainMenu" title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
+                        <items>
+                            <menuItem title="RunModalTestApp" id="1Xt-HY-uBw">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="RunModalTestApp" systemMenu="apple" id="uQy-DD-JDr">
+                                    <items>
+                                        <menuItem title="About RunModalTestApp" id="5kV-Vb-QxS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="orderFrontStandardAboutPanel:" target="Ady-hI-5gd" id="Exp-CZ-Vem"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
+                                        <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW"/>
+                                        <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>
+                                        <menuItem title="Services" id="NMo-om-nkz">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Services" systemMenu="services" id="hz9-B4-Xy5"/>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="4je-JR-u6R"/>
+                                        <menuItem title="Hide RunModalTestApp" keyEquivalent="h" id="Olw-nP-bQN">
+                                            <connections>
+                                                <action selector="hide:" target="Ady-hI-5gd" id="PnN-Uc-m68"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Hide Others" keyEquivalent="h" id="Vdr-fp-XzO">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="hideOtherApplications:" target="Ady-hI-5gd" id="VT4-aY-XCT"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Show All" id="Kd2-mp-pUS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="unhideAllApplications:" target="Ady-hI-5gd" id="Dhg-Le-xox"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="kCx-OE-vgT"/>
+                                        <menuItem title="Quit RunModalTestApp" keyEquivalent="q" id="4sb-4s-VLi">
+                                            <connections>
+                                                <action selector="terminate:" target="Ady-hI-5gd" id="Te7-pn-YzF"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Window" id="dMs-cI-mzQ">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Window" id="bib-Uj-vzu">
+                                    <items>
+                                        <menuItem title="New Modal" keyEquivalent="n" id="Was-JA-tGl">
+                                            <connections>
+                                                <action selector="showModal:" target="Voe-Tx-rLC" id="WQ6-Tx-XNW"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                        </items>
+                    </menu>
+                    <connections>
+                        <outlet property="delegate" destination="Voe-Tx-rLC" id="PrD-fu-P6m"/>
+                    </connections>
+                </application>
+                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="RunModalTestApp" customModuleProvider="target"/>
+                <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="0.0"/>
+        </scene>
+        <!--Window Controller-->
+        <scene sceneID="R2V-B0-nI4">
+            <objects>
+                <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+                        <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+                        <rect key="contentRect" x="196" y="240" width="480" height="270"/>
+                        <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+                    </window>
+                    <connections>
+                        <segue destination="XfG-lQ-9wD" kind="relationship" relationship="window.shadowedContentViewController" id="cq2-FE-JQM"/>
+                    </connections>
+                </windowController>
+                <customObject id="Oky-zY-oP4" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="250"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="hIz-AP-VOD">
+            <objects>
+                <viewController id="XfG-lQ-9wD" customClass="ViewController" customModule="RunModalTestApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" id="m2S-Jp-Qdl">
+                        <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tGd-Pe-B6x">
+                                <rect key="frame" x="14" y="222" width="107" height="32"/>
+                                <buttonCell key="cell" type="push" title="Run Modal" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="6jj-YL-bJW">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <segue destination="rA7-kv-bzh" kind="modal" id="OSq-8r-cwR"/>
+                                </connections>
+                            </button>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="okn-e0-Lwp">
+                                <rect key="frame" x="14" y="189" width="154" height="32"/>
+                                <buttonCell key="cell" type="push" title="Post a Notification" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="krr-rU-XpN">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="sendNotification:" target="XfG-lQ-9wD" id="Arw-fg-oNl"/>
+                                </connections>
+                            </button>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PzC-uR-GTC">
+                                <rect key="frame" x="20" y="133" width="442" height="42"/>
+                                <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Try checking whether the app hangup when open modal window from Menu (⌘N) and close it." id="LWo-Va-lLg">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                        </subviews>
+                    </view>
+                </viewController>
+                <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="655"/>
+        </scene>
+        <!--Modal View Controller-->
+        <scene sceneID="SY7-Kc-oJc">
+            <objects>
+                <viewController id="m8a-a5-gnv" customClass="ModalViewController" customModule="RunModalTestApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" id="7yo-jv-iUT">
+                        <rect key="frame" x="0.0" y="0.0" width="182" height="102"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Kwg-io-gdH">
+                                <rect key="frame" x="14" y="54" width="154" height="32"/>
+                                <buttonCell key="cell" type="push" title="Post a Notification" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="BTc-Al-825">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="sendNotification:" target="m8a-a5-gnv" id="OmO-2U-sge"/>
+                                </connections>
+                            </button>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="b2U-X9-R67">
+                                <rect key="frame" x="92" y="13" width="76" height="32"/>
+                                <buttonCell key="cell" type="push" title="Close" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Ze1-BW-66K">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="dismissController:" target="m8a-a5-gnv" id="wIG-Hw-fQa"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                    </view>
+                </viewController>
+                <customObject id="XBG-bB-3qd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="541" y="614"/>
+        </scene>
+        <!--Window Controller-->
+        <scene sceneID="Mkt-KV-r2O">
+            <objects>
+                <windowController storyboardIdentifier="ModalWindow" id="rA7-kv-bzh" customClass="ModalWindowController" customModule="RunModalTestApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="9sD-El-Rnf" customClass="ModalWindow" customModule="RunModalTestApp" customModuleProvider="target">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+                        <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+                        <rect key="contentRect" x="-1626" y="242" width="480" height="270"/>
+                        <rect key="screenRect" x="-1920" y="-120" width="1920" height="1177"/>
+                        <connections>
+                            <outlet property="delegate" destination="rA7-kv-bzh" id="347-9D-SOj"/>
+                        </connections>
+                    </window>
+                    <connections>
+                        <segue destination="m8a-a5-gnv" kind="relationship" relationship="window.shadowedContentViewController" id="V06-19-5Qp"/>
+                    </connections>
+                </windowController>
+                <customObject id="MRb-sT-0fC" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="656" y="293"/>
+        </scene>
+    </scenes>
+</document>

--- a/RunModalTestApp/Info.plist
+++ b/RunModalTestApp/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 平成27年 EasyStyle G.K. All rights reserved.</string>
+	<key>NSMainStoryboardFile</key>
+	<string>Main</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/RunModalTestApp/ModalViewController.swift
+++ b/RunModalTestApp/ModalViewController.swift
@@ -1,0 +1,29 @@
+//
+//  ModalViewController.swift
+//  ESNotification
+//
+//  Created by Tomohiro Kumagai on H27/08/13.
+//  Copyright © 平成27年 EasyStyle G.K. All rights reserved.
+//
+
+import Cocoa
+
+class ModalViewController: NSViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do view setup here.
+    }
+	
+	override func dismissController(sender: AnyObject?) {
+		
+		super.dismissController(sender)
+		
+		self.view.window?.close()
+	}
+	
+	@IBAction func sendNotification(sender:AnyObject?) {
+		
+		SampleNotification().post()
+	}
+}

--- a/RunModalTestApp/ModalWindow.swift
+++ b/RunModalTestApp/ModalWindow.swift
@@ -1,0 +1,13 @@
+//
+//  ModalWindow.swift
+//  ESNotification
+//
+//  Created by Tomohiro Kumagai on H27/08/13.
+//  Copyright © 平成27年 EasyStyle G.K. All rights reserved.
+//
+
+import Cocoa
+
+class ModalWindow: NSWindow {
+
+}

--- a/RunModalTestApp/ModalWindowController.swift
+++ b/RunModalTestApp/ModalWindowController.swift
@@ -1,0 +1,23 @@
+//
+//  ModalWindowController.swift
+//  ESNotification
+//
+//  Created by Tomohiro Kumagai on H27/08/13.
+//  Copyright © 平成27年 EasyStyle G.K. All rights reserved.
+//
+
+import Cocoa
+
+class ModalWindowController: NSWindowController, NSWindowDelegate {
+
+    override func windowDidLoad() {
+        super.windowDidLoad()
+    
+        // Implement this method to handle any initialization after your window controller's window has been loaded from its nib file.
+    }
+
+	func windowWillClose(notification: NSNotification) {
+		
+		NSApp.stopModal()
+	}
+}

--- a/RunModalTestApp/Notification.swift
+++ b/RunModalTestApp/Notification.swift
@@ -1,0 +1,14 @@
+//
+//  Notification.swift
+//  ESNotification
+//
+//  Created by Tomohiro Kumagai on H27/08/13.
+//  Copyright © 平成27年 EasyStyle G.K. All rights reserved.
+//
+
+import Foundation
+import ESNotification
+
+final class SampleNotification : Notification {
+	
+}

--- a/RunModalTestApp/ViewController.swift
+++ b/RunModalTestApp/ViewController.swift
@@ -1,0 +1,39 @@
+//
+//  ViewController.swift
+//  RunModalTestApp
+//
+//  Created by Tomohiro Kumagai on H27/08/13.
+//  Copyright © 平成27年 EasyStyle G.K. All rights reserved.
+//
+
+import Cocoa
+import ESNotification
+
+class ViewController: NSViewController {
+
+	override func viewDidLoad() {
+		super.viewDidLoad()
+
+		// Do any additional setup after loading the view.
+	}
+
+	override var representedObject: AnyObject? {
+		didSet {
+		// Update the view, if already loaded.
+		}
+	}
+
+	override func viewWillAppear() {
+		
+		SampleNotification.observeBy(self) { owner, notification in
+			
+			print("\(notification) received.")
+		}
+	}
+	
+	@IBAction func sendNotification(sender:AnyObject?) {
+		
+		SampleNotification().post()
+	}
+}
+


### PR DESCRIPTION
Fixed a problem that application will crash when receive a _NSWindowTransformAnimation notification when running a modal window in OS X.

モーダルウィンドウが表示されているときに非同期処理で _NSWindowTransformAnimation を取り扱うと object まわりでクラッシュするようだったため OS X に限り、通知を同期処理で裁くようにしました。
