### PR TITLE
Queue minimum notification only.

### DIFF
--- a/ESNotification.podspec
+++ b/ESNotification.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "ESNotification"
-  s.version      = "0.2.0"
+  s.version      = "0.2.1"
   s.summary      = "A type-safe notification management system for iOS/OSX written in Swift 2."
 
   s.description  = <<-DESC

--- a/ESNotification.xcodeproj/project.pbxproj
+++ b/ESNotification.xcodeproj/project.pbxproj
@@ -7,9 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		178BAE6E316CAD1990E70CF2 /* Pods_ObjCTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D85FA15D8D814FDF6075B5DB /* Pods_ObjCTestApp.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
-		343A9A080F9C7329E71BCB52 /* Pods_ESNotification_iOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94CC4F394FDA4C6F982B9551 /* Pods_ESNotification_iOSTests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
-		AB3373D115BB629CB46125EE /* Pods_ESNotification_OSXTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 905E50B34A8714B9C3580F67 /* Pods_ESNotification_OSXTests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		178BAE6E316CAD1990E70CF2 /* Pods_ObjCTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D85FA15D8D814FDF6075B5DB /* Pods_ObjCTestApp.framework */; };
+		343A9A080F9C7329E71BCB52 /* Pods_ESNotification_iOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94CC4F394FDA4C6F982B9551 /* Pods_ESNotification_iOSTests.framework */; };
+		AB3373D115BB629CB46125EE /* Pods_ESNotification_OSXTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 905E50B34A8714B9C3580F67 /* Pods_ESNotification_OSXTests.framework */; };
 		B125EA671B81E61D00714AF9 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B125EA661B81E61D00714AF9 /* AppDelegate.m */; };
 		B125EA6A1B81E61D00714AF9 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = B125EA691B81E61D00714AF9 /* main.m */; };
 		B125EA6D1B81E61D00714AF9 /* ESViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B125EA6C1B81E61D00714AF9 /* ESViewController.m */; };
@@ -50,9 +50,9 @@
 		B17475F31B6CE0D500A86785 /* RawNotificationConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17475E51B6CE0D500A86785 /* RawNotificationConvertible.swift */; };
 		B17475F61B6CE11200A86785 /* NotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17475F51B6CE11200A86785 /* NotificationTests.swift */; };
 		B17475F71B6CE11200A86785 /* NotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17475F51B6CE11200A86785 /* NotificationTests.swift */; };
-		C8F822083B65523B72E837B0 /* Pods_RunModalTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE62C38B0D23D1E3CFE0B2F2 /* Pods_RunModalTestApp.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
-		DA4177733F8741AACC0E09FD /* Pods_ESNotification_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD38000B9128AF3843B606EA /* Pods_ESNotification_iOS.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
-		E6CD40E556A62094744B1512 /* Pods_ESNotification_OSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C90ECBF946957FD1DEBF1072 /* Pods_ESNotification_OSX.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		C8F822083B65523B72E837B0 /* Pods_RunModalTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE62C38B0D23D1E3CFE0B2F2 /* Pods_RunModalTestApp.framework */; };
+		DA4177733F8741AACC0E09FD /* Pods_ESNotification_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD38000B9128AF3843B606EA /* Pods_ESNotification_iOS.framework */; };
+		E6CD40E556A62094744B1512 /* Pods_ESNotification_OSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C90ECBF946957FD1DEBF1072 /* Pods_ESNotification_OSX.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1016,7 +1016,6 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = ObjCTestApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
@@ -1035,7 +1034,6 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = ObjCTestApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
@@ -1052,7 +1050,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = RunModalTestApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
@@ -1068,7 +1065,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = RunModalTestApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
@@ -1254,7 +1250,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				PRODUCT_BUNDLE_IDENTIFIER = "jp.ez-style.appid.ESNotification-OSX";
+				PRODUCT_BUNDLE_IDENTIFIER = "jp.ez-style.appid.ESNotification_OSX";
 				PRODUCT_NAME = ESNotification;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1277,7 +1273,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				PRODUCT_BUNDLE_IDENTIFIER = "jp.ez-style.appid.ESNotification-OSX";
+				PRODUCT_BUNDLE_IDENTIFIER = "jp.ez-style.appid.ESNotification_OSX";
 				PRODUCT_NAME = ESNotification;
 				SKIP_INSTALL = YES;
 			};

--- a/ESNotification.xcodeproj/project.pbxproj
+++ b/ESNotification.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		B12BA0841B7BEB2F001F8080 /* ModalWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12BA0831B7BEB2F001F8080 /* ModalWindow.swift */; };
 		B12BA0861B7C0723001F8080 /* NotificationControl_OSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12BA0851B7C0723001F8080 /* NotificationControl_OSX.swift */; };
 		B12BA0881B7C072E001F8080 /* NotificationControl_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12BA0871B7C072E001F8080 /* NotificationControl_iOS.swift */; };
+		B142EB461BC80F9800EF9A98 /* NotificationBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = B142EB451BC80F9800EF9A98 /* NotificationBox.swift */; settings = {ASSET_TAGS = (); }; };
+		B142EB471BC80F9800EF9A98 /* NotificationBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = B142EB451BC80F9800EF9A98 /* NotificationBox.swift */; settings = {ASSET_TAGS = (); }; };
 		B17475A31B6CD4DE00A86785 /* ESNotification_iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = B17475A21B6CD4DE00A86785 /* ESNotification_iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B17475AA1B6CD4DE00A86785 /* ESNotification.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B17475A01B6CD4DE00A86785 /* ESNotification.framework */; };
 		B17475BF1B6CD4EB00A86785 /* ESNotification_OSX.h in Headers */ = {isa = PBXBuildFile; fileRef = B17475BE1B6CD4EB00A86785 /* ESNotification_OSX.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -146,6 +148,7 @@
 		B12BA0831B7BEB2F001F8080 /* ModalWindow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModalWindow.swift; sourceTree = "<group>"; };
 		B12BA0851B7C0723001F8080 /* NotificationControl_OSX.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationControl_OSX.swift; sourceTree = "<group>"; };
 		B12BA0871B7C072E001F8080 /* NotificationControl_iOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationControl_iOS.swift; sourceTree = "<group>"; };
+		B142EB451BC80F9800EF9A98 /* NotificationBox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationBox.swift; sourceTree = "<group>"; };
 		B17475A01B6CD4DE00A86785 /* ESNotification.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ESNotification.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B17475A21B6CD4DE00A86785 /* ESNotification_iOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ESNotification_iOS.h; sourceTree = "<group>"; };
 		B17475A41B6CD4DE00A86785 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -342,6 +345,7 @@
 			isa = PBXGroup;
 			children = (
 				B17475E01B6CE0D500A86785 /* Notification.swift */,
+				B142EB451BC80F9800EF9A98 /* NotificationBox.swift */,
 				B17475E11B6CE0D500A86785 /* NotificationControl.swift */,
 				B17475E21B6CE0D500A86785 /* NotificationManager.swift */,
 				B17475E31B6CE0D500A86785 /* NamedNotification.swift */,
@@ -917,6 +921,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B142EB461BC80F9800EF9A98 /* NotificationBox.swift in Sources */,
 				B17475E81B6CE0D500A86785 /* Notification.swift in Sources */,
 				B17475EE1B6CE0D500A86785 /* NamedNotification.swift in Sources */,
 				B17475F21B6CE0D500A86785 /* RawNotificationConvertible.swift in Sources */,
@@ -939,6 +944,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B142EB471BC80F9800EF9A98 /* NotificationBox.swift in Sources */,
 				B17475E91B6CE0D500A86785 /* Notification.swift in Sources */,
 				B17475EF1B6CE0D500A86785 /* NamedNotification.swift in Sources */,
 				B17475F31B6CE0D500A86785 /* RawNotificationConvertible.swift in Sources */,

--- a/ESNotification.xcodeproj/project.pbxproj
+++ b/ESNotification.xcodeproj/project.pbxproj
@@ -323,6 +323,7 @@
 				231D6053F4AABA988815BC2A /* Frameworks */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		B17475661B6CD4A500A86785 /* Products */ = {
 			isa = PBXGroup;

--- a/ESNotification/AnyNotification.swift
+++ b/ESNotification/AnyNotification.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 /// This notification type is used to handle any of notifications.
-@objc public class AnyNotification : NSObject, Notification {
+public final class AnyNotification : NSObject, Notification {
 
-	public private(set) var notification:Notification
+	public private(set) var notification:_Notification
 	
-	init(_ notification:Notification) {
+	init(_ notification:_Notification) {
 		
 		self.notification = notification
 		

--- a/ESNotification/NamedNotification.swift
+++ b/ESNotification/NamedNotification.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// This Notification represent almost the same thing as NSNotification.
-@objc public class NamedNotification : NSObject, Notification, RawNotificationConvertible, RawNotificationType {
+@objc public class NamedNotification : NSObject, _Notification, RawNotificationConvertible, RawNotificationType {
 	
 	public typealias UserInfo = [NSObject : AnyObject]
 	

--- a/ESNotification/Notification.swift
+++ b/ESNotification/Notification.swift
@@ -11,6 +11,11 @@ import Foundation
 // MARK: - Protocol
 
 /// All native notifications need to confirm to the protocol.
-@objc public protocol Notification : AnyObject {
+@objc public protocol Notification : _Notification {
+
+}
+
+/// All native notifications need to confirm to the protocol.
+@objc public protocol _Notification : AnyObject {
 	
 }

--- a/ESNotification/NotificationBox.swift
+++ b/ESNotification/NotificationBox.swift
@@ -1,0 +1,48 @@
+//
+//  NotificationBox.swift
+//  ESNotification
+//
+//  Created by Tomohiro Kumagai on H27/10/10.
+//  Copyright © 平成27年 EasyStyle G.K. All rights reserved.
+//
+
+import Foundation
+
+internal enum NotificationBox {
+	
+	case NativeNotification(_Notification)
+	case RawNotification(NSNotification)
+
+	func value() -> _Notification {
+		
+		guard case let .NativeNotification(value) = self else {
+			
+			fatalError("Type mismatch (expected \(_Notification.self)).")
+		}
+		
+		return value
+	}
+	
+	func value() -> NSNotification {
+		
+		guard case let .RawNotification(value) = self else {
+			
+			fatalError("Type mismatch (expected \(NSNotification.self)).")
+		}
+		
+		return value
+	}
+}
+
+extension RangeReplaceableCollectionType where Generator.Element == NotificationBox {
+	
+	mutating func append(notification:_Notification) {
+		
+		self.append(.NativeNotification(notification))
+	}
+	
+	mutating func append(notification:NSNotification) {
+		
+		self.append(.RawNotification(notification))
+	}
+}

--- a/ESNotification/NotificationControl.swift
+++ b/ESNotification/NotificationControl.swift
@@ -11,7 +11,7 @@ import ESThread
 
 private let NotificationRawNamePrefix = "jp.ez-style.Notification."
 
-extension Notification {
+extension _Notification {
 	
 	/// Post the `notification`.
 	public func post() {
@@ -49,7 +49,10 @@ extension Notification {
 			return NSNotification(name: name, object: object, userInfo:nil)
 		}
 	}
-	
+}
+
+extension Notification {
+
 	/// Observe an Native notification. When the native notification was post, the `handler` called in main thread.
 	public static func observeBy<OWNER:AnyObject>(owner:OWNER, handler:(OWNER,Self)->Void) -> NotificationManager.HandlerID {
 		
@@ -66,11 +69,11 @@ extension NSNotification {
 	}
 	
 	/// Get the native notification from the `rawNotification`. Returns nil if `rawNotification` is not an Native notification.
-	func toOceanNativeNotification() -> Notification? {
+	func toOceanNativeNotification() -> _Notification? {
 		
 		if self.isOceanNativeNotification {
 			
-			return self.object as? Notification
+			return self.object as? _Notification
 		}
 		else {
 			
@@ -84,13 +87,7 @@ extension NamedNotification {
 	/// Observe an Native notification. When the native notification was post, the `handler` called in main thread.
 	public static func observe<OWNER:AnyObject>(name:String, by owner:OWNER, handler:(OWNER,NamedNotification)->Void) -> NotificationManager.HandlerID {
 		
-		return _notificationManager.observe(owner) { (owner:OWNER, notification:NamedNotification) -> Void in
-			
-			if notification.name == name {
-
-				handler(owner, notification)
-			}
-		}
+		return _notificationManager.observe(owner, notificationName: name, handler: handler)
 	}
 }
 

--- a/ESNotificationTests/NotificationTests.swift
+++ b/ESNotificationTests/NotificationTests.swift
@@ -29,13 +29,11 @@ class NotificationTests: XCTestCase {
 
 	func testNotificationName() {
 	
-		let bundleName = NSBundle(forClass: self.dynamicType).infoDictionary!["CFBundleName"] as! String
-		
 		let customNotificationName = CustomNotification.self.notificationIdentifier
 		let namedNotificationName = NamedNotification("TestNamedNotification").notificationIdentifier
 		
-		expected().equal(customNotificationName, "jp.ez-style.Notification." + bundleName + ".CustomNotification")
-		expected("NamedNotification も nameOf 関数では名前ではなく固有の識別子を取得します。").equal(namedNotificationName, "jp.ez-style.Notification.ESNotification.NamedNotification")
+		expected().equal(customNotificationName, "jp.ez-style.Notification.CustomNotification")
+		expected("NamedNotification も nameOf 関数では名前ではなく固有の識別子を取得します。").equal(namedNotificationName, "jp.ez-style.Notification.NamedNotification")
 	}
 	
     func testRawNotification() {

--- a/ESNotification_OSX/NotificationControl_OSX.swift
+++ b/ESNotification_OSX/NotificationControl_OSX.swift
@@ -10,8 +10,14 @@ import Cocoa
 
 public func invokeOnProcessingQueueSyncIfNeeded(predicate:()->Void) -> Void {
 
-	// In OSX, always invoke synchronously.
-	// Because when modal window shown from menu in OSX, need to invoke synchronously.
-	// Otherwise the app clash when _NSWindowTransformAnimation notification is received.
-	invokeOnProcessingQueueSynchronously(predicate)
+	// In OSX, processing for notification no longer invoke synchronously.
+	//
+	// Formerly when modal window shown from menu in OSX, need to invoke synchronously.
+	// Otherwise the app is clashed when _NSWindowTransformAnimation notification is received.
+	//
+	// It has been improved by optimizing for named notification.
+	// Because the 'invokeOnProcessingQueueSyncIfNeeded' method can remove,
+	// but I change invoke mode sync to async without remove the method,
+	// and observe whether this modification does not cause some problem.
+	invokeOnProcessingQueue(predicate)
 }

--- a/RunModalTestApp/Base.lproj/Main.storyboard
+++ b/RunModalTestApp/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="8173.3" systemVersion="14E46" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="15A284" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8173.3"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8191"/>
     </dependencies>
     <scenes>
         <!--Application-->
@@ -105,6 +105,7 @@
                         <subviews>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tGd-Pe-B6x">
                                 <rect key="frame" x="359" y="222" width="107" height="32"/>
+                                <animations/>
                                 <buttonCell key="cell" type="push" title="Run Modal" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="6jj-YL-bJW">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -115,6 +116,7 @@
                             </button>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="okn-e0-Lwp">
                                 <rect key="frame" x="14" y="222" width="197" height="32"/>
+                                <animations/>
                                 <buttonCell key="cell" type="push" title="Post a Native Notification" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="krr-rU-XpN">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -125,6 +127,7 @@
                             </button>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="roC-mB-mEm">
                                 <rect key="frame" x="14" y="189" width="215" height="32"/>
+                                <animations/>
                                 <buttonCell key="cell" type="push" title="Post a Named Notification A" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="V5K-EH-qHg">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -135,6 +138,7 @@
                             </button>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zUP-HF-rUW">
                                 <rect key="frame" x="16" y="156" width="215" height="32"/>
+                                <animations/>
                                 <buttonCell key="cell" type="push" title="Post a Named Notification B" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="GWS-pv-Yd1">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -145,6 +149,7 @@
                             </button>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="A2e-k8-5Td">
                                 <rect key="frame" x="367" y="189" width="99" height="32"/>
+                                <animations/>
                                 <buttonCell key="cell" type="push" title="Dumming" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="FA8-L1-jUR">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -155,6 +160,7 @@
                             </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PzC-uR-GTC">
                                 <rect key="frame" x="20" y="95" width="442" height="42"/>
+                                <animations/>
                                 <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Try checking whether the app hangup when open modal window from Menu (⌘N) and close it." id="LWo-Va-lLg">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -162,6 +168,7 @@
                                 </textFieldCell>
                             </textField>
                         </subviews>
+                        <animations/>
                     </view>
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -178,6 +185,7 @@
                         <subviews>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Kwg-io-gdH">
                                 <rect key="frame" x="14" y="54" width="154" height="32"/>
+                                <animations/>
                                 <buttonCell key="cell" type="push" title="Post a Notification" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="BTc-Al-825">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -188,6 +196,7 @@
                             </button>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="b2U-X9-R67">
                                 <rect key="frame" x="92" y="13" width="76" height="32"/>
+                                <animations/>
                                 <buttonCell key="cell" type="push" title="Close" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Ze1-BW-66K">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -197,6 +206,7 @@
                                 </connections>
                             </button>
                         </subviews>
+                        <animations/>
                     </view>
                 </viewController>
                 <customObject id="XBG-bB-3qd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
#4 問題を解消しました。

OS X での利用において、従来の NSNotofication をハンドルした際に runModal されていると、モーダル状態が解かれた時に、モーダル表示していたウィンドウの NSWindow に関する通知を内部で受け取って実行時エラーになることがありました。

原因は、NSWindow を object に設定する通知を内部で NativeNotification に変換する時に、その object がすでに解放されているために BAD_ACCESS で落ちるためでした。

そこで、ハンドラーに渡す前に NSNotification を NativeNotification に変換することをやめ、NSNotification を受け取った場合は、先にその名前を対象とするハンドラーが登録されているかを調べ、登録されている場合に限って NativeNotification に変換するようにしました。

これにより、問題を起こす通知名をハンドラーに設定していない限りは落ちなくなりました。ただし、どこかでその通知名をハンドルするハンドラーが登録されて生存している間にモーダルモードに突入すると、その通知も変換対象になるため落ちる可能性は残されています。
