### PR TITLE
ESNotification can now receive raw notifications more safely.

### DIFF
--- a/ESNotification.podspec
+++ b/ESNotification.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "ESNotification"
-  s.version      = "0.2.1"
+  s.version      = "0.2.2"
   s.summary      = "A type-safe notification management system for iOS/OSX written in Swift 2."
 
   s.description  = <<-DESC

--- a/ESNotification_OSX/NotificationControl_OSX.swift
+++ b/ESNotification_OSX/NotificationControl_OSX.swift
@@ -10,14 +10,8 @@ import Cocoa
 
 public func invokeOnProcessingQueueSyncIfNeeded(predicate:()->Void) -> Void {
 
-	// In OSX, processing for notification no longer invoke synchronously.
-	//
-	// Formerly when modal window shown from menu in OSX, need to invoke synchronously.
-	// Otherwise the app is clashed when _NSWindowTransformAnimation notification is received.
-	//
-	// It has been improved by optimizing for named notification.
-	// Because the 'invokeOnProcessingQueueSyncIfNeeded' method can remove,
-	// but I change invoke mode sync to async without remove the method,
-	// and observe whether this modification does not cause some problem.
-	invokeOnProcessingQueue(predicate)
+	// In OSX, always invoke synchronously.
+	// Because when modal window shown from menu in OSX, need to invoke synchronously.
+	// Otherwise the app clash when _NSWindowTransformAnimation notification is received.
+	invokeOnProcessingQueueSynchronously(predicate)
 }


### PR DESCRIPTION
#5 で OS X でも RawNotification を非同期処理で扱うようにしましたが、それが原因でモーダルウィンドウ表示時に BAD_ACCESS になることがあったため、再び同期処理するようにしました。
